### PR TITLE
エラーではないログは標準エラー出力ではなく標準出力に出す

### DIFF
--- a/cmd/kulasis_client/login.go
+++ b/cmd/kulasis_client/login.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"fmt"
 	"github.com/KMConner/kyodai-go/internal"
 	"github.com/KMConner/kyodai-go/kulasis"
 	"golang.org/x/crypto/ssh/terminal"
@@ -29,7 +30,7 @@ func (opts *loginOptions) Execute(_ []string) error {
 	}
 
 	pass := string(bpass)
-	println()
+	fmt.Println()
 
 	info, err := kulasis.SignIn(id, pass)
 	if err != nil {
@@ -37,8 +38,8 @@ func (opts *loginOptions) Execute(_ []string) error {
 	}
 
 	if opts.PrintToConsole {
-		println("AccountNo: " + info.Account)
-		println("Access Token: " + info.AccessToken)
+		fmt.Println("AccountNo: " + info.Account)
+		fmt.Println("Access Token: " + info.AccessToken)
 	} else {
 		err = internal.Store(*info)
 		return err

--- a/cmd/kulasis_client/mail.go
+++ b/cmd/kulasis_client/mail.go
@@ -35,7 +35,7 @@ func (opt *getMailOptions) Execute(_ []string) error {
 	for i, l := range lectures {
 		fmt.Printf("%d: %s\n", i+1, l.LectureName)
 	}
-	println("Select lectures to read course mail.")
+	fmt.Println("Select lectures to read course mail.")
 
 	reader := bufio.NewReader(os.Stdin)
 	numStr, err := reader.ReadString('\n')

--- a/cmd/mail_notifier/main.go
+++ b/cmd/mail_notifier/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"github.com/KMConner/kyodai-go/kulasis"
 	"os"
 )
@@ -21,8 +22,8 @@ func main() {
 
 	news := slot.GetNewLecture()
 	for _, v := range news {
-		println(v.LectureName)
+		fmt.Println(v.LectureName)
 		m, _ := v.GetCourseMailTitles()
-		println(len(*m))
+		fmt.Println(len(*m))
 	}
 }


### PR DESCRIPTION
## Why

Goのビルドイン関数である `println` は内容を標準エラー出力に出力します。
エラーでないログは標準エラー出力よりも標準出力に出した方が良いと思います。

https://golang.org/pkg/builtin/#println

## What
- エラーではないログは `fmt.Println()` を使って標準出力に出すように修正
	- エラーログはそのまま `println` を使ってます。